### PR TITLE
Removing cached enqueues for main css and js files. - fix/1

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 ## Change log
 
+### 1.1.2
+* Fix - Removing cached enqueues for main css and js files.
+
 ## 1.1.1 - September 27 2019
 * Fix - Removing gulp-minify-css and updating to gulp 4+
 * Dev - Adding the .gitattributes file to remove unnecessary files from the WordPress version.

--- a/classes/class-lsx-videos-admin.php
+++ b/classes/class-lsx-videos-admin.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * LSX Videos Admin Class.
  *
@@ -229,17 +230,17 @@ class LSX_Videos_Admin {
 	 * Enqueue JS and CSS.
 	 */
 	public function assets( $hook ) {
-		// wp_enqueue_media();
+		//wp_enqueue_media();
 		wp_enqueue_script( 'media-upload' );
 		wp_enqueue_script( 'thickbox' );
 		wp_enqueue_style( 'thickbox' );
 
-		wp_enqueue_script( 'lsx-videos-admin', LSX_VIDEOS_URL . 'assets/js/lsx-videos-admin.min.js', array( 'jquery' ), LSX_VIDEOS_VER, true );
-		wp_enqueue_style( 'lsx-videos-admin', LSX_VIDEOS_URL . 'assets/css/lsx-videos-admin.css', array(), LSX_VIDEOS_VER );
+		wp_enqueue_script( 'lsx-videos-admin', LSX_VIDEOS_URL . 'assets/js/lsx-videos-admin.min.js', array( 'jquery' ), null, true );
+		wp_enqueue_style( 'lsx-videos-admin', LSX_VIDEOS_URL . 'assets/css/lsx-videos-admin.css', array(), null );
 	}
 
 	/**
-	 * Handle body colours that might be change by LSX Customiser.
+	 * Handle body colours that might be change by LSX Customizer.
 	 */
 	public function customizer_body_colours_handler( $css, $colors ) {
 		$css .= '

--- a/classes/class-lsx-videos-frontend.php
+++ b/classes/class-lsx-videos-frontend.php
@@ -53,7 +53,7 @@ class LSX_Videos_Frontend {
 			wp_enqueue_script( 'slick', LSX_VIDEOS_URL . 'assets/js/vendor/slick.min.js', array( 'jquery' ), null, LSX_VIDEOS_URL, true );
 		}
 
-		wp_enqueue_script( 'lsx-videos', LSX_VIDEOS_URL . 'assets/js/lsx-videos.min.js', array( 'jquery', 'slick' ), LSX_VIDEOS_VER, true );
+		wp_enqueue_script( 'lsx-videos', LSX_VIDEOS_URL . 'assets/js/lsx-videos.min.js', array( 'jquery', 'slick' ), null, true );
 
 		$params = apply_filters( 'lsx_videos_js_params', array(
 			'ajax_url' => admin_url( 'admin-ajax.php' ),
@@ -61,7 +61,7 @@ class LSX_Videos_Frontend {
 
 		wp_localize_script( 'lsx-videos', 'lsx_videos_params', $params );
 
-		wp_enqueue_style( 'lsx-videos', LSX_VIDEOS_URL . 'assets/css/lsx-videos.css', array( 'slick' ), LSX_VIDEOS_VER );
+		wp_enqueue_style( 'lsx-videos', LSX_VIDEOS_URL . 'assets/css/lsx-videos.css', array(), null );
 		wp_style_add_data( 'lsx-videos', 'rtl', 'replace' );
 	}
 


### PR DESCRIPTION
**Problem**
The latest version of LSX Videos plugin is not loading the JS file (lsx-videos.min.js) and the CSS file (lsx-videos.css) on the frontend of the site.

**Solution**
Remove the parameter for calling a cached version on the css and js main file enqueuing.

**To Test**
- Make sure you have video posts types to show
- Call a videos shortcode
- inspect the code and make sure the `lsx-videos.css` and the `lsx-videos.min.js` files are being called.
- make sure the videos carousel is working as expected.

**Issue Reported**
https://github.com/lightspeeddevelopment/lsx-videos/issues/1
