### PR TITLE
JS loading on front

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,9 @@
 ### Added
 - Added the excerpt on the videos shortcode.
 
+### Fixed
+- Fixed the issue where sometimes the videos.js was not loaded on front.
+
 
 ## [[1.1.2]](https://github.com/lightspeeddevelopment/lsx-videos/releases/tag/1.1.2) - 2020-03-30
 

--- a/classes/class-lsx-videos-frontend.php
+++ b/classes/class-lsx-videos-frontend.php
@@ -46,20 +46,20 @@ class LSX_Videos_Frontend {
 	 * Enqueue JS and CSS.
 	 */
 	public function assets() {
-		$has_slick = wp_script_is( 'slick', 'queue' );
+		$has_slick = wp_script_is( 'slick.min.js', 'queue' );
 
 		if ( ! $has_slick ) {
 			wp_enqueue_style( 'slick', LSX_VIDEOS_URL . 'assets/css/vendor/slick.css', array(), LSX_VIDEOS_URL, null );
-			wp_enqueue_script( 'slick', LSX_VIDEOS_URL . 'assets/js/vendor/slick.min.js', array( 'jquery' ), null, LSX_VIDEOS_URL, true );
+			wp_enqueue_script( 'slick', LSX_VIDEOS_URL . 'assets/js/vendor/slick.min.js', array( 'jquery' ), null );
 		}
 
-		wp_enqueue_script( 'lsx-videos', LSX_VIDEOS_URL . 'assets/js/lsx-videos.min.js', array( 'jquery', 'slick' ), null, true );
+		wp_enqueue_script( 'lsx-videos-js', LSX_VIDEOS_URL . 'assets/js/lsx-videos.min.js', array( 'jquery', 'slick' ), null );
 
 		$params = apply_filters( 'lsx_videos_js_params', array(
 			'ajax_url' => admin_url( 'admin-ajax.php' ),
 		));
 
-		wp_localize_script( 'lsx-videos', 'lsx_videos_params', $params );
+		wp_localize_script( 'lsx-videos-js', 'lsx_videos_params', $params );
 
 		wp_enqueue_style( 'lsx-videos', LSX_VIDEOS_URL . 'assets/css/lsx-videos.css', array(), null );
 		wp_style_add_data( 'lsx-videos', 'rtl', 'replace' );

--- a/classes/class-lsx-videos.php
+++ b/classes/class-lsx-videos.php
@@ -127,6 +127,7 @@ class LSX_Videos {
 			}
 
 			while ( $videos->have_posts() ) {
+				$video_url = '';
 				$videos->the_post();
 
 				$count++;


### PR DESCRIPTION
### Description of the Change

- Fixed the issue where sometimes the videos.js was not loaded on front.

### Benefits

- It will always load the script it needs for the carousel to work.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests passed.